### PR TITLE
grab remote target on cell pickup

### DIFF
--- a/goal_src/jak1/engine/mods/mod-common-functions.gc
+++ b/goal_src/jak1/engine/mods/mod-common-functions.gc
@@ -167,6 +167,7 @@
       (let* ((remote-cell (birth-pickup-at-point (-> remote-target control trans) (pickup-type fuel-cell) 1.0 #f remote-target (the-as fact-info #f))))
         (safe-deactivate-remote-cell)
         (set! (-> (the-as fuel-cell (ppointer->process remote-cell)) name) "remote-cell")
+        (process-grab? remote-target)
         (go-virtual-process (the-as fuel-cell (ppointer->process remote-cell)) pickup #f (process->handle remote-target))
       )
     )

--- a/goal_src/jak1/engine/mods/mod-common-functions.gc
+++ b/goal_src/jak1/engine/mods/mod-common-functions.gc
@@ -530,6 +530,7 @@
                 )
               )
           (target-sync-state (-> p tgt_state) t (-> p inter_name))
+          (update-transforms! (-> t control))
           )
         )
         ;; cleanup after sync state as some states uses interaction, don't cleanup on warp out as we skip interactions during this to avoid crashes

--- a/goal_src/jak1/engine/target/logic-target.gc
+++ b/goal_src/jak1/engine/target/logic-target.gc
@@ -773,9 +773,12 @@
               (move-by-vector! (-> self control) s4-1)
               (vector-float*! (-> self control rider-last-move) s4-1 (-> *display* frames-per-second))
               (set-time! (-> self control rider-time))
-              (if (and (time-elapsed? (-> self control unknown-dword41) (seconds 0.5))
-                        (time-elapsed? (-> self control unknown-dword40) (seconds 0.5)))
-                (send-event self 'end-mode)))
+              ;; og:teamruns prevent occasional fall anim loop on remote targets
+              (if (and (= self *target*)
+                       (time-elapsed? (-> self control unknown-dword41) (seconds 0.5))
+                       (time-elapsed? (-> self control unknown-dword40) (seconds 0.5)))
+                (send-event self 'end-mode)
+                (set! (-> self control unknown-float110) 0.0)))
               (else
               (let ((a1-6 (new 'stack-no-clear 'vector)))
                 (vector-! a1-6 (-> s5-0 center-hold) (-> self control unknown-vector91))


### PR DESCRIPTION
I was not able to replicate the first video in #41, but this fixes the behavior seen in the second video.

Also fixes remote target `target-edge-grab` behavior (falling animation loop and collision desync).

Fixes #41